### PR TITLE
Release/for deploy GitHub actions

### DIFF
--- a/.github/workflows/build_and_push_docker_image.yml
+++ b/.github/workflows/build_and_push_docker_image.yml
@@ -1,0 +1,30 @@
+name: Build and Deploy
+on:
+  workflow_dispatch:
+    branches: [ main ]
+  push: 
+    branches: [ main ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # レポジトリのチェックアウト
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      # dockerxを使用可能にする
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      # github packagesにログイン
+      - name: Login GitHub Packages
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # プロジェクトルートのDockerfileをビルドして、ghcr.io/username/guild-mng-bot:latestとして公開する
+      - name: build for bot
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.actor }}/guild-mng-bot:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   bot:
-    build: .
+    image: ghcr.io/sylx/guild-mng-bot:latest
     # init: true  # docker stackでは使えないので不可
     # .envファイルではなく、環境変数を使用するが、docker-compose.ymlに直接書くのはよくないので、以下のようにする
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   bot:
-    image: ghcr.io/sylx/guild-mng-bot:latest
+    image: ghcr.io/sonozakiSZ/guild-mng-bot:latest
     # init: true  # docker stackでは使えないので不可
     # .envファイルではなく、環境変数を使用するが、docker-compose.ymlに直接書くのはよくないので、以下のようにする
     environment:


### PR DESCRIPTION
> なんか、docker-composeのbuild: . がdocker swarmだとどうやっても動かない（ようするに、デプロイ時に自動ビルドするのは無理で、必ず何らかのレジストリにimageを登録しないといけない）という問題に直面してしもうた。

でしたが、思うところあって、やはりgithub actionsでimageを作成する方向に舵を切りました。
というわけでmergeしてください。
